### PR TITLE
feat: update functions

### DIFF
--- a/solidity/ExpirableAirdrop.sol
+++ b/solidity/ExpirableAirdrop.sol
@@ -13,8 +13,8 @@ contract ExpirableAirdrop is Governable {
   using SafeERC20 for IERC20;
 
   IERC20 public immutable token;
-  uint256 public immutable expirationTimestamp;
-  bytes32 public immutable merkleRoot;
+  uint256 public expirationTimestamp;
+  bytes32 public merkleRoot;
   mapping(address => bool) public hasClaimed;
 
   error AlreadyClaimed();
@@ -25,6 +25,8 @@ contract ExpirableAirdrop is Governable {
   event Claimed(address _claimee, address _receiver, uint256 _amount);
   event Deposited(uint256 _amount);
   event Retrieved(address _receiver);
+  event MerkleRootUpdated(bytes32 _oldMerkleRoot, bytes32 _newMerkleRoot);
+  event ExpirationTimestampUpdated(uint256 _oldExpirationTimestamp, uint256 _newExpirationTimestamp);
 
   /// @notice Creates a new ExpirableAirdrop contract
   /// @param _govAddy governor address
@@ -106,5 +108,25 @@ contract ExpirableAirdrop is Governable {
     token.safeTransfer(governor, token.balanceOf(address(this)));
 
     emit Retrieved(governor);
+  }
+
+  /// @notice Used by governor to update the merkle root
+  /// @param _newMerkleRoot new merkle root
+  function updateMerkleRoot(bytes32 _newMerkleRoot) external onlyGovernor {
+    // EFFECTS
+    bytes32 _oldMerkleRoot = merkleRoot;
+    merkleRoot = _newMerkleRoot;
+
+    emit MerkleRootUpdated(_oldMerkleRoot, _newMerkleRoot);
+  }
+
+  /// @notice Used by governor to update the expiration timestamp
+  /// @param _newExpirationTimestamp new expiration timestamp
+  function updateExpirationTimestamp(uint256 _newExpirationTimestamp) external onlyGovernor {
+    // EFFECTS
+    uint256 _oldExpirationTimestamp = expirationTimestamp;
+    expirationTimestamp = _newExpirationTimestamp;
+
+    emit ExpirationTimestampUpdated(_oldExpirationTimestamp, _newExpirationTimestamp);
   }
 }

--- a/test/e2e/expirable-airdrop.spec.ts
+++ b/test/e2e/expirable-airdrop.spec.ts
@@ -289,4 +289,58 @@ describe('Expirable airdrop', () => {
       });
     });
   });
+
+  describe('updateMerkleRoot()', () => {
+    let newMerkleRoot: Uint8Array;
+
+    given(async () => {
+      newMerkleRoot = ethers.utils.randomBytes(32);
+    });
+
+    when('caller is not governor', () => {
+      then('revert with custom error', async () => {
+        await expect(expirableAirdrop.connect(alice).updateMerkleRoot(newMerkleRoot)).to.be.revertedWithCustomError(
+          expirableAirdrop,
+          'OnlyGovernor'
+        );
+      });
+    });
+
+    when('caller is governor', () => {
+      given(async () => {
+        await expirableAirdrop.connect(deployer).updateMerkleRoot(newMerkleRoot);
+      });
+
+      then('merkle root should have the new value', async () => {
+        expect(await expirableAirdrop.merkleRoot()).equal(ethers.utils.hexlify(newMerkleRoot));
+      });
+    });
+  });
+
+  describe('updateExpirationTimestamp()', () => {
+    let newExpirationTimestamp: number;
+
+    given(async () => {
+      let nowTimestamp: number = await time.latest();
+      newExpirationTimestamp = nowTimestamp + 4 * oneMonth;
+    });
+
+    when('caller is not governor', () => {
+      then('revert with custom error', async () => {
+        await expect(expirableAirdrop.connect(alice).updateExpirationTimestamp(newExpirationTimestamp)).to.be.revertedWithCustomError(
+          expirableAirdrop,
+          'OnlyGovernor'
+        );
+      });
+    });
+
+    when('caller is governor', () => {
+      given(async () => {
+        await expirableAirdrop.connect(deployer).updateExpirationTimestamp(newExpirationTimestamp);
+      });
+      then('expiration timestamp should have the new value', async () => {
+        expect((await expirableAirdrop.expirationTimestamp()).toNumber()).equal(newExpirationTimestamp);
+      });
+    });
+  });
 });

--- a/test/e2e/expirable-airdrop.spec.ts
+++ b/test/e2e/expirable-airdrop.spec.ts
@@ -307,12 +307,22 @@ describe('Expirable airdrop', () => {
     });
 
     when('caller is governor', () => {
+      let tx: Transaction;
+      let oldMerkleRoot: Uint8Array;
+
       given(async () => {
-        await expirableAirdrop.connect(deployer).updateMerkleRoot(newMerkleRoot);
+        oldMerkleRoot = await expirableAirdrop.merkleRoot();
+        tx = await expirableAirdrop.connect(deployer).updateMerkleRoot(newMerkleRoot);
       });
 
       then('merkle root should have the new value', async () => {
         expect(await expirableAirdrop.merkleRoot()).equal(ethers.utils.hexlify(newMerkleRoot));
+      });
+
+      then('event is emitted', async () => {
+        expect(tx)
+          .to.have.emit(expirableAirdrop, 'MerkleRootUpdated')
+          .withArgs(ethers.utils.hexlify(oldMerkleRoot), ethers.utils.hexlify(newMerkleRoot));
       });
     });
   });
@@ -321,7 +331,7 @@ describe('Expirable airdrop', () => {
     let newExpirationTimestamp: number;
 
     given(async () => {
-      let nowTimestamp: number = await time.latest();
+      const nowTimestamp: number = await time.latest();
       newExpirationTimestamp = nowTimestamp + 4 * oneMonth;
     });
 
@@ -335,11 +345,19 @@ describe('Expirable airdrop', () => {
     });
 
     when('caller is governor', () => {
+      let tx: Transaction;
+      let oldExpirationTimestamp: BigNumber;
+
       given(async () => {
         await expirableAirdrop.connect(deployer).updateExpirationTimestamp(newExpirationTimestamp);
       });
+
       then('expiration timestamp should have the new value', async () => {
         expect((await expirableAirdrop.expirationTimestamp()).toNumber()).equal(newExpirationTimestamp);
+      });
+
+      then('event is emitted', async () => {
+        expect(tx).to.have.emit(expirableAirdrop, 'ExpirationTimestampUpdated').withArgs(oldExpirationTimestamp, toUnit(newExpirationTimestamp));
       });
     });
   });


### PR DESCRIPTION
As Nico suggested: [here](https://github.com/Mean-Finance/op-expirable-airdrop/pull/1#discussion_r929167729), I created functions to update merkle root and expiration timestamp.